### PR TITLE
Implement default applied date and simplify job form

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,8 +11,6 @@ function App() {
   const [company, setCompany] = useState(""); // Holds company name
   const [title, setTitle] = useState(""); // Holds job title
   const [location, setLocation] = useState(""); // Holds job location
-  const [dateApplied, setDateApplied] = useState(""); // Holds date applied
-  const [stage, setStage] = useState(""); // Holds job stage
   const [contactInfo, setContactInfo] = useState(""); // Holds contact info
   const [notes, setNotes] = useState(""); // Holds notes
   const [salary, setSalary] = useState(""); // Holds salary
@@ -28,11 +26,9 @@ function App() {
       company_name: company,
       job_title: title,
       location: location,
-      date_applied: dateApplied,
-      stage: stage,
-      contact_info: contactInfo,
-      notes: notes,
-      salary: salary,
+      contact_info: contactInfo || null,
+      notes: notes || null,
+      salary: salary ? parseInt(salary, 10) : null,
     };
   
     fetch("http://localhost:8000/jobs", {
@@ -76,8 +72,6 @@ function App() {
         setCompany("");
         setTitle("");
         setLocation("");
-        setDateApplied("");
-        setStage("");
         setContactInfo("");
         setNotes("");
         setSalary("");
@@ -128,16 +122,12 @@ function App() {
         company={company}
         title={title}
         location={location}
-        dateApplied={dateApplied}
-        stage={stage}
         contactInfo={contactInfo}
         notes={notes}
         salary={salary}
         setCompany={setCompany}
         setTitle={setTitle}
         setLocation={setLocation}
-        setDateApplied={setDateApplied}
-        setStage={setStage}
         setContactInfo={setContactInfo}
         setNotes={setNotes}
         setSalary={setSalary}

--- a/frontend/src/JobForm.js
+++ b/frontend/src/JobForm.js
@@ -1,7 +1,7 @@
-function JobForm({ company, title, location, dateApplied, stage, 
+function JobForm({ company, title, location,
     contactInfo, notes, salary,
-    setCompany, setTitle, setLocation, setDateApplied, setStage, 
-    setContactInfo, setNotes, setSalary, 
+    setCompany, setTitle, setLocation,
+    setContactInfo, setNotes, setSalary,
     resumeFile, setResumeFile,
     handleSubmit }) {
     return (
@@ -23,18 +23,6 @@ function JobForm({ company, title, location, dateApplied, stage,
                 placeholder="Job Location"
                 value={location}
                 onChange={((e) => setLocation(e.target.value))}
-            />
-            <input
-                type="date"
-                placeholder="Date Applied"
-                value={dateApplied}
-                onChange={((e) => setDateApplied(e.target.value))}
-            />
-            <input
-                type="text"
-                placeholder="Stage"
-                value={stage}
-                onChange={((e) => setStage(e.target.value))}
             />
             <input
                 type="text"


### PR DESCRIPTION
## Summary
- set date applied automatically on the backend
- drop date and stage fields from the frontend job form
- allow optional contact info, notes, and salary values

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853834c72f483329f58785e14810bd1